### PR TITLE
Fix spec file to work with delorean

### DIFF
--- a/instack.spec
+++ b/instack.spec
@@ -25,7 +25,7 @@ OpenStack locally from both diskimage-builder elements and
 openstack-tripleo-image-elements.
 
 %prep
-%setup -q
+%setup -q -n instack-%{upstream_version}
 
 %build
 %{__python2} setup.py build


### PR DESCRIPTION
Delorean exports an upstream_version variable to rpmbuild. We need
to pass that to setup in the spec file in order to have naming
consitent with how the source tarball is named.
